### PR TITLE
feat: support opfs watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +341,7 @@ dependencies = [
  "cfg-if",
  "futures",
  "js-sys",
+ "notify-types",
  "pin-project-lite",
  "rustc-hash",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ keywords = ["tokio", "fs", "wasm", "opfs"]
 crate-type = ["cdylib", "rlib"]
 
 [features]
-wasm_offload = ["tokio/sync"]
+default = []
+opfs_offload = ["tokio/sync"]
+opfs_watch = ["tokio/sync", "notify-types"]
 opfs_tracing = ["tracing"]
 
 [dependencies]
@@ -57,6 +59,7 @@ wasm-bindgen-futures = { version = "0.4.50", features = [
 tokio = { version = "1.46.1", default-features = false, optional = true }
 bitflags = "2.9.1"
 rustc-hash = "2.1.1"
+notify-types = { version = "2.0.0", optional = true }
 tracing = { version = "0.1.41", optional = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dev-dependencies]

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -16,8 +16,11 @@ cfg_if! {
 
         pub use wasm::ReadDirStream;
 
-        #[cfg(feature = "wasm_offload")]
+        #[cfg(feature = "opfs_offload")]
         pub use wasm::offload;
+
+        #[cfg(feature = "opfs_watch")]
+        pub use wasm::watch;
 
     } else if #[cfg(any(target_family = "unix", target_family = "windows"))] {
 

--- a/src/fs/wasm/mod.rs
+++ b/src/fs/wasm/mod.rs
@@ -45,5 +45,8 @@ pub use symlink_metadata::symlink_metadata;
 pub use try_exists::try_exists;
 pub use write::write;
 
-#[cfg(feature = "wasm_offload")]
+#[cfg(feature = "opfs_offload")]
 pub mod offload;
+
+#[cfg(feature = "opfs_watch")]
+pub use opfs::watch;

--- a/src/fs/wasm/offload/client.rs
+++ b/src/fs/wasm/offload/client.rs
@@ -2,6 +2,8 @@ use std::{io, path::Path};
 
 use tokio::sync::{mpsc, oneshot};
 
+#[cfg(feature = "opfs_watch")]
+use super::super::opfs::watch::event;
 use super::{FsTask, Metadata, ReadDir};
 
 #[derive(Clone)]
@@ -66,6 +68,23 @@ impl Client {
         let path = path.as_ref().into();
         self.dispatch(|sender| FsTask::Metadata { path, sender })
             .await
+    }
+
+    #[cfg(feature = "opfs_watch")]
+    pub async fn watch_dir(
+        &self,
+        path: impl AsRef<Path>,
+        recursive: bool,
+        cb: impl Fn(event::Event) + Send + Sync + 'static,
+    ) -> io::Result<()> {
+        let path = path.as_ref().into();
+        self.dispatch(|sender| FsTask::WatchDir {
+            path,
+            recursive,
+            cb: Box::new(cb),
+            sender,
+        })
+        .await
     }
 
     async fn dispatch<T, F>(&self, create_task: F) -> io::Result<T>

--- a/src/fs/wasm/opfs/mod.rs
+++ b/src/fs/wasm/opfs/mod.rs
@@ -6,6 +6,8 @@ mod options;
 mod remove;
 mod root;
 mod virtualize;
+#[cfg(feature = "opfs_watch")]
+pub mod watch;
 
 pub(super) use error::OpfsError;
 pub(super) use open_dir::open_dir;

--- a/src/fs/wasm/opfs/watch.rs
+++ b/src/fs/wasm/opfs/watch.rs
@@ -1,0 +1,205 @@
+use std::{
+    io,
+    path::{MAIN_SEPARATOR_STR, Path},
+};
+
+use js_sys::{Array, JsString};
+pub use notify_types::event;
+use wasm_bindgen::{
+    JsCast,
+    prelude::{Closure, wasm_bindgen},
+};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{FileSystemDirectoryHandle, FileSystemHandle, FileSystemSyncAccessHandle};
+
+use super::{super::opfs::OpfsError, CreateFileMode, OpenDirType, SyncAccessMode, open_file};
+
+#[wasm_bindgen]
+extern "C" {
+    // https://developer.mozilla.org/en-US/docs/Web/API/FileSystemObserver
+    #[wasm_bindgen(extends = js_sys::Object, js_name = FileSystemObserver, typescript_type = "FileSystemObserver")]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub type FileSystemObserver;
+
+    #[wasm_bindgen(constructor, js_class = "FileSystemObserver")]
+    pub fn new(callback: &js_sys::Function) -> FileSystemObserver;
+
+    #[wasm_bindgen (method, structural, js_class = "FileSystemObserver", js_name = observe)]
+    pub fn observe_file(
+        this: &FileSystemObserver,
+        target: &FileSystemSyncAccessHandle,
+    ) -> js_sys::Promise;
+
+    #[wasm_bindgen (method, structural, js_class = "FileSystemObserver", js_name = observe)]
+    pub fn observe_dir(
+        this: &FileSystemObserver,
+        handdle: &FileSystemSyncAccessHandle,
+    ) -> js_sys::Promise;
+
+    #[wasm_bindgen (method, structural, js_class = "FileSystemObserver", js_name = observe)]
+    pub fn observe_dir_with_options(
+        this: &FileSystemObserver,
+        handdle: &FileSystemDirectoryHandle,
+        options: &FileSystemDirObserverOptions,
+    ) -> js_sys::Promise;
+
+    #[wasm_bindgen (method, structural, js_class = "FileSystemObserver", js_name = disconnect)]
+    pub fn disconnect(this: &FileSystemObserver);
+
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen (extends = js_sys::Object , js_name = FileSystemObserverOptions)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub type FileSystemDirObserverOptions;
+    #[wasm_bindgen(method, getter = "recursive")]
+    pub fn get_recursive(this: &FileSystemDirObserverOptions) -> Option<bool>;
+    #[wasm_bindgen(method, setter = "recursive")]
+    pub fn set_recursive(this: &FileSystemDirObserverOptions, val: bool);
+}
+impl FileSystemDirObserverOptions {
+    pub fn new() -> Self {
+        wasm_bindgen::JsCast::unchecked_into(js_sys::Object::new())
+    }
+}
+
+impl Default for FileSystemDirObserverOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends = js_sys::Object , js_name = FileSystemChangeRecord)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub type FileSystemChangeRecord;
+
+    #[wasm_bindgen (method, getter, js_class = "FileSystemChangeRecord", js_name = type)]
+    pub fn r#type(this: &FileSystemChangeRecord) -> FileSystemChangeRecordType;
+
+    #[wasm_bindgen(method, getter, structural, js_class = "FileSystemChangeRecord", js_name = relativePathComponents)]
+    pub fn relative_path_components(this: &FileSystemChangeRecord) -> Array;
+
+    #[wasm_bindgen(method, getter, structural, js_class = "FileSystemChangeRecord", js_name = changedHandle)]
+    pub fn changed_handle(this: &FileSystemChangeRecord) -> FileSystemHandle;
+
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/FileSystemChangeRecord#type
+#[wasm_bindgen]
+pub enum FileSystemChangeRecordType {
+    Appeared = "appeared",
+    Disappeared = "disappeared",
+    Errored = "errored",
+    Modified = "modified",
+    Moved = "moved",
+    Unknown = "unknown",
+}
+
+impl From<&FileSystemChangeRecord> for event::Event {
+    fn from(record: &FileSystemChangeRecord) -> Self {
+        let kind = record.changed_handle().kind();
+
+        event::Event {
+            kind: match record.r#type() {
+                FileSystemChangeRecordType::Appeared => event::EventKind::Create(match kind {
+                    web_sys::FileSystemHandleKind::File => event::CreateKind::File,
+                    web_sys::FileSystemHandleKind::Directory => event::CreateKind::Folder,
+                    _ => event::CreateKind::Any,
+                }),
+                FileSystemChangeRecordType::Disappeared => event::EventKind::Remove(match kind {
+                    web_sys::FileSystemHandleKind::File => event::RemoveKind::File,
+                    web_sys::FileSystemHandleKind::Directory => event::RemoveKind::Folder,
+                    _ => event::RemoveKind::Any,
+                }),
+                FileSystemChangeRecordType::Modified => match kind {
+                    web_sys::FileSystemHandleKind::File => {
+                        event::EventKind::Modify(event::ModifyKind::Data(event::DataChange::Any))
+                    }
+                    web_sys::FileSystemHandleKind::Directory => event::EventKind::Modify(
+                        event::ModifyKind::Metadata(event::MetadataKind::Any),
+                    ),
+                    _ => event::EventKind::Modify(event::ModifyKind::Any),
+                },
+                FileSystemChangeRecordType::Moved => {
+                    event::EventKind::Modify(event::ModifyKind::Name(event::RenameMode::Any))
+                }
+                FileSystemChangeRecordType::Unknown => event::EventKind::Other,
+                FileSystemChangeRecordType::Errored => event::EventKind::Other,
+                FileSystemChangeRecordType::__Invalid => event::EventKind::Other,
+            },
+            paths: vec![
+                format!(
+                    "./{}",
+                    record
+                        .relative_path_components()
+                        .iter()
+                        .map(|p| String::from(p.unchecked_ref::<JsString>()))
+                        .collect::<Vec<_>>()
+                        .join(MAIN_SEPARATOR_STR)
+                )
+                .into(),
+            ],
+            ..Default::default()
+        }
+    }
+}
+
+pub async fn watch_dir(
+    path: impl AsRef<Path>,
+    recursive: bool,
+    cb: impl Fn(event::Event) + Send + Sync + 'static,
+) -> io::Result<()> {
+    let observer = FileSystemObserver::new(
+        Closure::<dyn Fn(Array)>::new(move |records: Array| {
+            records.iter().for_each(|record| {
+                let event = event::Event::from(record.unchecked_ref::<FileSystemChangeRecord>());
+                cb(event)
+            });
+        })
+        .into_js_value()
+        .unchecked_ref(),
+    );
+
+    let dir_handle = super::open_dir(path, OpenDirType::NotCreate).await?;
+    let options = FileSystemDirObserverOptions::new();
+    options.set_recursive(recursive);
+    JsFuture::from(observer.observe_dir_with_options(&dir_handle, &options))
+        .await
+        .map_err(|e| OpfsError::from(e).into_io_err())?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub async fn watch_file(
+    path: impl AsRef<Path>,
+    cb: impl Fn(event::Event) + Send + Sync + 'static,
+) -> io::Result<()> {
+    let observer = FileSystemObserver::new(
+        Closure::<dyn Fn(Array)>::new(move |records: Array| {
+            records.iter().for_each(|record| {
+                let event = event::Event::from(record.unchecked_ref::<FileSystemChangeRecord>());
+                cb(event)
+            });
+        })
+        .into_js_value()
+        .unchecked_ref(),
+    );
+
+    let file_handle = open_file(
+        path,
+        CreateFileMode::NotCreate,
+        SyncAccessMode::Readonly,
+        false,
+    )
+    .await?
+    .sync_access_handle
+    .clone();
+
+    JsFuture::from(observer.observe_file(&file_handle))
+        .await
+        .map_err(|e| OpfsError::from(e).into_io_err())?;
+    Ok(())
+}


### PR DESCRIPTION
Support [OPFS](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system) watch via [FileSystemObserver](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemObserver)