### PR TITLE
fix(opfs): retry on stale cached directory handle

### DIFF
--- a/src/fs/wasm/opfs/open_dir.rs
+++ b/src/fs/wasm/opfs/open_dir.rs
@@ -11,7 +11,7 @@ use web_sys::{FileSystemDirectoryHandle, FileSystemGetDirectoryOptions};
 use crate::fs::wasm::current_dir::current_dir;
 
 use super::{
-    dir_handle_cache::{get_cached_dir_handle, set_cached_dir_handle},
+    dir_handle_cache::{get_cached_dir_handle, remove_cached_dir_handle, set_cached_dir_handle},
     opfs_err,
     options::OpenDirType,
     root::root,
@@ -29,6 +29,24 @@ pub(crate) async fn open_dir(
         return Ok(handle);
     }
 
+    match open_dir_inner(&virt, r#type).await {
+        Ok(handle) => Ok(handle),
+        Err(e) if e.kind() == io::ErrorKind::InvalidInput => {
+            // InvalidInput maps from OPFS InvalidStateError — a cached
+            // directory handle has gone stale.  Evict the entire subtree
+            // cache and retry once from a fresh root.
+            remove_cached_dir_handle(&PathBuf::from("/"), true);
+            super::root::clear_cached_root();
+            open_dir_inner(&virt, r#type).await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+async fn open_dir_inner(
+    virt: &Path,
+    r#type: OpenDirType,
+) -> io::Result<FileSystemDirectoryHandle> {
     let components: Vec<Cow<'_, str>> = virt
         .components()
         .filter_map(|c| match c {

--- a/src/fs/wasm/opfs/root.rs
+++ b/src/fs/wasm/opfs/root.rs
@@ -28,3 +28,8 @@ pub(super) async fn root() -> io::Result<FileSystemDirectoryHandle> {
         Some(root) => Ok(root.clone()),
     }
 }
+
+pub(super) fn clear_cached_root() {
+    CACHED_ROOT.with(|cell| cell.take());
+}
+


### PR DESCRIPTION
When a cached `FileSystemDirectoryHandle` becomes stale (e.g. after concurrent `remove_dir_all` + recreate), OPFS throws `InvalidStateError`, which can cause downstream operations to fail or hang.

## Changes

- Extract directory walk into `open_dir_inner` for clean retry
- On `InvalidStateError` (`io::ErrorKind::InvalidInput`), evict the entire dir handle cache and retry once from root
- No infinite retry — single attempt only

## Root Cause

`DIR_HANDLE_CACHE` stores `FileSystemDirectoryHandle` objects keyed by path. When concurrent operations modify the OPFS tree (e.g. `remove_dir_all` followed by `create_dir_all` on overlapping paths), cached handles become stale. Using a stale handle as a parent in `get_directory_handle_with_options` throws `InvalidStateError`.